### PR TITLE
Bump commons-fileupload from 1.4 to 1.5 in /java/demo

### DIFF
--- a/java/demo/pom.xml
+++ b/java/demo/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>1.4</version>
+      <version>1.5</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>


### PR DESCRIPTION
Push commit merge approved


Bumps commons-fileupload from 1.4 to 1.5.

---
updated-dependencies:
- dependency-name: commons-fileupload:commons-fileupload dependency-type: direct:production ...